### PR TITLE
Refactor environment variables

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-VUE_APP_URL="http://localhost:8080/"
-VUE_APP_CDN="http://localhost:4000/"
+VUE_APP_URL="http://localhost:8080"
+VUE_APP_CDN="http://localhost:4000"

--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,2 @@
 VUE_APP_URL="http://localhost:8080/"
-VUE_APP_SERVER="http://localhost:4000/"
 VUE_APP_CDN="http://localhost:4000/"

--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,4 @@
+# PlantUML Editor App URL
 VUE_APP_URL="http://localhost:8080"
+# PlantUML Server URL
 VUE_APP_CDN="http://localhost:4000"

--- a/.env.test
+++ b/.env.test
@@ -1,2 +1,2 @@
-VUE_APP_URL="http://localhost:8080/"
-VUE_APP_CDN="http://localhost:4000/"
+VUE_APP_URL="http://localhost:8080"
+VUE_APP_CDN="http://localhost:4000"

--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,2 @@
 VUE_APP_URL="http://localhost:8080/"
-VUE_APP_SERVER="http://localhost:4000/"
 VUE_APP_CDN="http://localhost:4000/"

--- a/.env.test
+++ b/.env.test
@@ -1,2 +1,4 @@
+# PlantUML Editor App URL
 VUE_APP_URL="http://localhost:8080"
+# PlantUML Server URL
 VUE_APP_CDN="http://localhost:4000"

--- a/README.md
+++ b/README.md
@@ -91,13 +91,22 @@ docker run -d -p 8080:80 --name plantuml-editor plantuml-editor
 
 ## For development
 
-[PlantUML Server with Docker](https://hub.docker.com/r/plantuml/plantuml-server/)
+### [PlantUML Server with Docker](https://hub.docker.com/r/plantuml/plantuml-server/)
 
 ```bash
 docker run -d -p 4000:8080 plantuml/plantuml-server:jetty
 ```
 
 > **Notice:** The specification of the port number follows `.env.development`
+
+### [Kroki with Docker](https://hub.docker.com/r/yuzutech/kroki) as alternative to PlantUML Server:
+
+```
+docker run -d -p 4000:8000 yuzutech/kroki
+```
+
+> **Notice:** Kroki uses for PlantUML the relative path `plantuml`.
+> `VUE_APP_CDN` in `.env.development` would in this case be for example: `VUE_APP_CDN="http://localhost:4000/plantuml"`
 
 ## Other
 

--- a/src/components/CheatSheet/CheatSheetMixin.js
+++ b/src/components/CheatSheet/CheatSheetMixin.js
@@ -12,7 +12,7 @@ export default {
   methods: {
     createUrl(img: string): string {
       const extension: string = 'svg'
-      return `${this.$store.state.plantumlEditor.cdn}${extension}/${img}.${extension}`
+      return `${this.$store.state.plantumlEditor.cdn}/${extension}/${img}.${extension}`
     },
   },
 }

--- a/src/components/HistoryList.vue
+++ b/src/components/HistoryList.vue
@@ -65,7 +65,7 @@ export default {
   },
   methods: {
     createUrl(encodedText: string, extension: string = 'png'): string {
-      return `${this.$store.state.plantumlEditor.cdn}${extension}/${encodedText}.${extension}`
+      return `${this.$store.state.plantumlEditor.cdn}/${extension}/${encodedText}.${extension}`
     },
     setLazyloadEvent() {
       this.$Lazyload.$on('loaded', ({ el, naturalHeight }: any) => {

--- a/src/store/modules/PlantumlEditor.js
+++ b/src/store/modules/PlantumlEditor.js
@@ -191,7 +191,7 @@ const mutations: any = {
     if (start && end) {
       const uml: string = `${start}${String(text.split(start)[1]).split(end)[0] || ''}${end}`
       state.encodedText = plantumlEncoder.encode(uml)
-      state.src = `${state.cdn}${state.umlExtension}/${state.encodedText}.${state.umlExtension}`
+      state.src = `${state.cdn}/${state.umlExtension}/${state.encodedText}.${state.umlExtension}`
     }
   },
   renderMarkdown(state: any, text: string) {

--- a/src/store/modules/PlantumlEditor.js
+++ b/src/store/modules/PlantumlEditor.js
@@ -13,7 +13,6 @@ const state: any = {
   url: process.env.VUE_APP_URL,
   official: 'https://plantuml.com',
   plantuml: 'plantuml',
-  server: process.env.VUE_APP_SERVER,
   cdn: process.env.VUE_APP_CDN,
   startuml: ['@startuml', '@startmindmap', '@startditaa', '@startgantt', '@startwbs'],
   enduml: ['@enduml', '@endmindmap', '@endditaa', '@endgantt', '@endwbs'],

--- a/tests/unit/UmlTemplate.spec.js
+++ b/tests/unit/UmlTemplate.spec.js
@@ -23,7 +23,7 @@ describe('UmlTemplate.vue', () => {
 
     it('state.plantumlEditor.src', () => {
       expect(vm.$store.state.plantumlEditor.src).toEqual(
-        `${process.env.VUE_APP_CDN}svg/SoWkIImgAStDuU9AJ2x9Br9mXD9EN5oE2hgb1Rfs2Xgb1PeWJb5cUaO9Y9-ScbUIMWGMIyalpmC9WMYmG4vg6bWDYDRaud92DiC98GqpmWd9M303B8HgAfT3QbuAq8a0.svg`
+        `${process.env.VUE_APP_CDN}/svg/SoWkIImgAStDuU9AJ2x9Br9mXD9EN5oE2hgb1Rfs2Xgb1PeWJb5cUaO9Y9-ScbUIMWGMIyalpmC9WMYmG4vg6bWDYDRaud92DiC98GqpmWd9M303B8HgAfT3QbuAq8a0.svg`
       )
     })
   })


### PR DESCRIPTION
Just a few small things that make using plantuml-editor easier and more accessible.

- remove unused environment variable `VUE_APP_SERVER`
- do not force users to append a tailing `/` on URLs (It's still supported but not necessary anymore.)
- add comments to environment variables to quickly understand their purpose
- add example instructions (readme) for [Kroki](https://kroki.io) as alternative to PlantUML Server