### PR TITLE
Add further diagram support and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ jsconfig.json
 
 # flow-typed install でインストール出来るもの
 flow-typed
+
+# docker
+docker-compose.override.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,8 @@ COPY . /usr/app
 
 WORKDIR /usr/app
 
-# NOTE: tailing "/" is important! (At least for VUE_APP_CDN.)
-ENV VUE_APP_URL=https://plantuml-editor.kkeisuke.com/
-ENV VUE_APP_SERVER=https://plantuml-server.kkeisuke.dev/
-ENV VUE_APP_CDN=https://plantuml-server.kkeisuke.dev/
+ENV VUE_APP_URL=https://plantuml-editor.kkeisuke.com
+ENV VUE_APP_CDN=https://plantuml-server.kkeisuke.dev
 
 # build app
 RUN npm install && \

--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ If this is not possible without merge conflicts, an appropriate pull request is 
 #### Additional Features
 
 - dockerized on [Docker Hub](https://hub.docker.com/r/heinrichad/plantuml-editor)
+- add relative path (URL) support \[[PR#1](https://github.com/HeinrichAD/plantuml-editor/pull/1)\]
+- update URLs to use https \[[PR#2](https://github.com/HeinrichAD/plantuml-editor/pull/2)\]
+- refactor environment variables \[[PR#3](https://github.com/HeinrichAD/plantuml-editor/pull/3)\]
+- add further diagram support \[[PR#4](https://github.com/HeinrichAD/plantuml-editor/pull/4)\]
+  * [json](https://plantuml.com/json)
+  * [latex](https://plantuml.com/ascii-math)
+  * [math](https://plantuml.com/ascii-math)
+  * [salt](https://plantuml.com/salt)
+  * [yaml](https://plantuml.com/yaml)
 
 ## Features
 
@@ -75,9 +84,8 @@ npm run test:e2e
 # build with docker
 docker build \
        -t plantuml-editor \
-       --env VUE_APP_URL=http://localhost:8080/ \
-       --env VUE_APP_SERVER=http://localhost:4000/ \
-       --env VUE_APP_CDN=http://localhost:4000/ \
+       --env VUE_APP_URL=http://localhost:8080 \
+       --env VUE_APP_CDN=http://localhost:4000 \
        .
 
 # run plantuml-editor server with docker
@@ -107,6 +115,8 @@ docker run -d -p 4000:8000 yuzutech/kroki
 
 > **Notice:** Kroki uses for PlantUML the relative path `plantuml`.
 > `VUE_APP_CDN` in `.env.development` would in this case be for example: `VUE_APP_CDN="http://localhost:4000/plantuml"`
+
+> **Notice:** Kroki does not support `@startlatex` and `@startmath`.
 
 ## Other
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,7 @@ services:
     container_name: plantuml-editor
     environment:
       - VUE_APP_URL=http://localhost:8080
-      - VUE_APP_SERVER=http://localhost:4000/
-      - VUE_APP_CDN=http://localhost:4000/
+      - VUE_APP_CDN=http://localhost:4000
       #- TZ=...
     ports:
       - 8080:80

--- a/src/store/modules/PlantumlEditor.js
+++ b/src/store/modules/PlantumlEditor.js
@@ -14,8 +14,8 @@ const state: any = {
   official: 'https://plantuml.com',
   plantuml: 'plantuml',
   cdn: process.env.VUE_APP_CDN,
-  startuml: ['@startuml', '@startmindmap', '@startditaa', '@startgantt', '@startwbs'],
-  enduml: ['@enduml', '@endmindmap', '@endditaa', '@endgantt', '@endwbs'],
+  startuml: ['@startuml', '@startmindmap', '@startditaa', '@startgantt', '@startwbs', '@startjson', '@startsalt', '@startyaml', '@startmath', '@startlatex'],
+  enduml: ['@enduml', '@endmindmap', '@endditaa', '@endgantt', '@endwbs', '@endjson', '@endsalt', '@endyaml', '@endmath', '@endlatex'],
   defaultText:
     '# PlantUML Editor\n\n1. select template\n2. write uml diagram\n\n@startuml\n\nleft to right direction\n\nactor User\n\nUser --> (1. select template)\nUser --> (2. write uml diagram)\n\n@enduml',
   text: '',


### PR DESCRIPTION
Add further diagram support:
- [json](https://plantuml.com/json)
- [latex](https://plantuml.com/ascii-math)
- [math](https://plantuml.com/ascii-math)
- [salt](https://plantuml.com/salt)
- [yaml](https://plantuml.com/yaml)

Add more documentation.

Remove unnecessary environment variable from `Dockerfile` and `docker-compose.yml`.